### PR TITLE
Final files for 2024.07.0

### DIFF
--- a/custom_components/mqtt_vacuum_camera/utils/users_data.py
+++ b/custom_components/mqtt_vacuum_camera/utils/users_data.py
@@ -122,7 +122,6 @@ async def async_find_last_logged_in_user(hass: HomeAssistant) -> str or None:
                 last_user = user
 
     if last_user:
-        _LOGGER.info(f"Last logged-in user: {last_user.id}")
         return last_user.id
     else:
         _LOGGER.info("No users have logged in yet.")

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -194,7 +194,7 @@ class ValetudoConnector:
         Generate a Warning message if the vacuum is disconnected.
         """
         if self._mqtt_vac_connect_state == "disconnected":
-            _LOGGER.warning(
+            _LOGGER.debug(
                 f"{self._mqtt_topic}: Vacuum Disconnected from MQTT, waiting for connection."
             )
             self._mqtt_vac_stat = "disconnected"

--- a/custom_components/mqtt_vacuum_camera/valetudo/hypfer/handler_utils.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/hypfer/handler_utils.py
@@ -75,7 +75,7 @@ class ImageUtils:
         _LOGGER.debug(
             f"{self.file_name}: Found trims max and min values (y,x) "
             f"({int(max_y)}, {int(max_x)}) ({int(min_y)},{int(min_x)})..."
-            )
+        )
 
         return min_y, min_x, max_x, max_y
 


### PR DESCRIPTION
Logging: Canged Warning to Debug level for Vacuum disconnected as at 3:00 AM it always discoonect (due to vacuum firmware).  Removed the user login loged entry,  this is to avoid repeated entries when HA is in standby.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected logging statement indentation in image margin function for better readability.

- **Refactor**
  - Changed log severity from warning to debug for vacuum disconnection events to reduce unnecessary alerts.
  - Removed logging of the last logged-in user to streamline user data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->