### PR TITLE
Solving issue #209 

### DIFF
--- a/custom_components/mqtt_vacuum_camera/__init__.py
+++ b/custom_components/mqtt_vacuum_camera/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     CONF_VACUUM_IDENTIFIERS,
     DOMAIN,
 )
-from .utils.users_data import (
+from .utils.files_operations import (
     async_get_translations_vacuum_id,
     async_rename_room_description,
 )

--- a/custom_components/mqtt_vacuum_camera/__init__.py
+++ b/custom_components/mqtt_vacuum_camera/__init__.py
@@ -303,7 +303,7 @@ async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:
     async def handle_homeassistant_stop(event):
         """Handle Home Assistant stop event."""
         _LOGGER.info("Home Assistant is stopping. Writing down the rooms data.")
-        storage = hass.config.path(STORAGE_DIR, "valetudo_camera")
+        storage = hass.config.path(STORAGE_DIR, CAMERA_STORAGE)
         if not os.path.exists(storage):
             _LOGGER.debug(f"Storage path: {storage} do not exists. Aborting!")
             return False

--- a/custom_components/mqtt_vacuum_camera/camera.py
+++ b/custom_components/mqtt_vacuum_camera/camera.py
@@ -58,10 +58,7 @@ from .const import (
 )
 from .snapshots.snapshot import Snapshots
 from .utils.colors_man import ColorsManagment
-from .utils.files_operations import (
-    async_get_active_user_language,
-    is_auth_updated,
-)
+from .utils.files_operations import async_get_active_user_language, is_auth_updated
 from .valetudo.MQTT.connector import ValetudoConnector
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/custom_components/mqtt_vacuum_camera/camera.py
+++ b/custom_components/mqtt_vacuum_camera/camera.py
@@ -58,7 +58,7 @@ from .const import (
 )
 from .snapshots.snapshot import Snapshots
 from .utils.colors_man import ColorsManagment
-from .utils.users_data import async_get_active_user_language, is_auth_updated
+from .utils.files_operations import async_get_active_user_language, is_auth_updated
 from .valetudo.MQTT.connector import ValetudoConnector
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(

--- a/custom_components/mqtt_vacuum_camera/camera.py
+++ b/custom_components/mqtt_vacuum_camera/camera.py
@@ -60,7 +60,6 @@ from .snapshots.snapshot import Snapshots
 from .utils.colors_man import ColorsManagment
 from .utils.files_operations import (
     async_get_active_user_language,
-    async_save_mqtt_room_data,
     is_auth_updated,
 )
 from .valetudo.MQTT.connector import ValetudoConnector
@@ -359,15 +358,6 @@ class ValetudoCamera(Camera):
                 self.run_async_pil_to_bytes(pil_img)
             )
             return self.Image
-
-        if self.startup:
-            if await async_save_mqtt_room_data(
-                self.hass, self._file_name, self._mqtt.get_segments()
-            ):
-                _LOGGER.info(f"Rooms data saved for {self._file_name}.")
-            else:
-                _LOGGER.info(f"No rooms data save for {self._file_name}.")
-            self.startup = False
 
         # If we have data from MQTT, we process the image.
         self._shared.vacuum_battery = await self._mqtt.get_battery_level()

--- a/custom_components/mqtt_vacuum_camera/camera_processing.py
+++ b/custom_components/mqtt_vacuum_camera/camera_processing.py
@@ -8,9 +8,9 @@ avoid the overload of the main_thread of Home Assistant.
 from __future__ import annotations
 
 import asyncio
-import logging
 from asyncio import gather, get_event_loop
 import concurrent.futures
+import logging
 
 from .types import Color, JsonType, PilPNG
 from .utils.drawable import Drawable as Draw

--- a/custom_components/mqtt_vacuum_camera/camera_processing.py
+++ b/custom_components/mqtt_vacuum_camera/camera_processing.py
@@ -14,8 +14,8 @@ import logging
 
 from .types import Color, JsonType, PilPNG
 from .utils.drawable import Drawable as Draw
+from .utils.files_operations import async_get_active_user_language
 from .utils.status_text import StatusText
-from .utils.users_data import async_get_active_user_language
 from .valetudo.hypfer.image_handler import MapImageHandler
 from .valetudo.rand256.image_handler import ReImageHandler
 

--- a/custom_components/mqtt_vacuum_camera/common.py
+++ b/custom_components/mqtt_vacuum_camera/common.py
@@ -5,11 +5,8 @@ Version: 2024.07.4
 
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
 import re
-from typing import Any
 
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
@@ -110,67 +107,7 @@ async def update_options(bk_options, new_options):
     return updated_bk_options
 
 
-async def async_load_file(file_to_load: str, is_json: bool = False) -> Any:
-    """Asynchronously load JSON data from a file."""
-    loop = asyncio.get_event_loop()
-
-    def read_file(my_file: str, read_json: bool = False):
-        """Helper function to read data from a file."""
-        try:
-            if read_json:
-                with open(my_file) as file:
-                    return json.load(file)
-            else:
-                with open(my_file) as file:
-                    return file.read()
-        except (FileNotFoundError, json.JSONDecodeError):
-            _LOGGER.warning(f"{my_file} does not exist.")
-            return None
-
-    try:
-        return await loop.run_in_executor(None, read_file, file_to_load, is_json)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        _LOGGER.warning(f"Blocking IO issue detected: {e}")
-        return None
-
-
-async def async_write_json_to_disk(file_to_write: str, json_data) -> None:
-    """Asynchronously write data to a JSON file."""
-    loop = asyncio.get_event_loop()
-
-    def _write_to_file(file_path, data):
-        """Helper function to write data to a file."""
-        with open(file_path, "w") as datafile:
-            json.dump(data, datafile, indent=2)
-
-    try:
-        await loop.run_in_executor(None, _write_to_file, file_to_write, json_data)
-    except OSError as e:
-        _LOGGER.warning(f"Blocking issue detected: {e}")
-
-
-async def async_write_file_to_disk(
-    file_to_write: str, data, is_binary: bool = False
-) -> None:
-    """Asynchronously write data to a file."""
-    loop = asyncio.get_event_loop()
-
-    def _write_to_file(file_path, data_to_write, binary_mode):
-        """Helper function to write data to a file."""
-        if binary_mode:
-            with open(file_path, "wb") as datafile:
-                datafile.write(data_to_write)
-        else:
-            with open(file_path, "w") as datafile:
-                datafile.write(data_to_write)
-
-    try:
-        await loop.run_in_executor(None, _write_to_file, file_to_write, data, is_binary)
-    except OSError as e:
-        _LOGGER.warning(f"Blocking issue detected: {e}")
-
-
 def extract_file_name(unique_id: str) -> str:
     """Extract from the Camera unique_id the file name."""
-    file_name = re.sub(r'_camera$', '', unique_id)
+    file_name = re.sub(r"_camera$", "", unique_id)
     return file_name.lower()

--- a/custom_components/mqtt_vacuum_camera/common.py
+++ b/custom_components/mqtt_vacuum_camera/common.py
@@ -5,6 +5,7 @@ Version: 2024.07.0
 
 from __future__ import annotations
 
+import logging
 import asyncio
 import json
 from typing import Any
@@ -15,8 +16,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import _LOGGER, KEYS_TO_UPDATE
+from .const import KEYS_TO_UPDATE
 from .hass_types import GET_MQTT_DATA
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_device_info(

--- a/custom_components/mqtt_vacuum_camera/common.py
+++ b/custom_components/mqtt_vacuum_camera/common.py
@@ -1,13 +1,14 @@
 """
-Common functions for the Valetudo Vacuum Camera integration.
-Version: 2024.07.0
+Common functions for the MQTT Vacuum Camera integration.
+Version: 2024.07.4
 """
 
 from __future__ import annotations
 
-import logging
 import asyncio
 import json
+import logging
+import re
 from typing import Any
 
 from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN
@@ -167,3 +168,10 @@ async def async_write_file_to_disk(
         await loop.run_in_executor(None, _write_to_file, file_to_write, data, is_binary)
     except OSError as e:
         _LOGGER.warning(f"Blocking issue detected: {e}")
+
+
+def extract_file_name(unique_id: str) -> str:
+    """Extract from the Camera unique_id the file name."""
+    pattern = re.compile(r"_camera$")
+    file_name = re.sub(pattern, "", unique_id)
+    return file_name.lower()

--- a/custom_components/mqtt_vacuum_camera/common.py
+++ b/custom_components/mqtt_vacuum_camera/common.py
@@ -172,6 +172,5 @@ async def async_write_file_to_disk(
 
 def extract_file_name(unique_id: str) -> str:
     """Extract from the Camera unique_id the file name."""
-    pattern = re.compile(r"_camera$")
-    file_name = re.sub(pattern, "", unique_id)
+    file_name = re.sub(r'_camera$', '', unique_id)
     return file_name.lower()

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -87,11 +87,8 @@ from .const import (
     ROTATION_VALUES,
     TEXT_SIZE_VALUES,
 )
-from .utils.files_operations import (
-    async_del_file,
-    async_get_rooms_count,
-    async_rename_room_description,
-)
+from .types import RoomStore
+from .utils.files_operations import async_del_file, async_rename_room_description
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -347,7 +344,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         _LOGGER.info(f"{self.config_entry.unique_id}: Options Configuration Started.")
         errors = {}
 
-        self.number_of_rooms = await async_get_rooms_count(self.hass, self.file_name)
+        self.number_of_rooms = RoomStore().get_rooms_count(self.file_name)
         if (
             not isinstance(self.number_of_rooms, int)
             or self.number_of_rooms < DEFAULT_ROOMS

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -839,14 +839,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """
         Copy the logs from .storage to www config folder.
         """
+        _LOGGER.debug("Renaming the translations.")
         hass = self.hass
         storage_path = hass.config.path(STORAGE_DIR, CAMERA_STORAGE)
         _LOGGER.debug(f"Looking for Storage Path: {storage_path}")
         if (user_input is None) and self.bk_options:
             if self.hass:
-                await hass.async_add_executor_job(
-                    async_rename_room_description, hass, storage_path, self.file_name
-                )
+                await async_rename_room_description(hass, storage_path, self.file_name)
                 self.options = self.bk_options
             return await self.async_step_opt_save()
 

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -344,7 +344,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         _LOGGER.info(f"{self.config_entry.unique_id}: Options Configuration Started.")
         errors = {}
 
-        self.number_of_rooms = RoomStore().get_rooms_count(self.file_name)
+        self.number_of_rooms = await RoomStore().async_get_rooms_count(self.file_name)
         if (
             not isinstance(self.number_of_rooms, int)
             or self.number_of_rooms < DEFAULT_ROOMS

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -1,4 +1,4 @@
-"""config_flow 2024.07.2
+"""config_flow 2024.07.4
 IMPORTANT: Maintain code when adding new options to the camera
 it will be mandatory to update const.py and common.py update_options.
 Format of the new constants must be CONST_NAME = "const_name" update also
@@ -31,6 +31,7 @@ from homeassistant.helpers.storage import STORAGE_DIR
 import voluptuous as vol
 
 from .common import (
+    extract_file_name,
     get_device_info,
     get_vacuum_mqtt_topic,
     get_vacuum_unique_id_from_mqtt_topic,
@@ -182,7 +183,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.unique_id = self.config_entry.unique_id
         self.options = {}
         self.bk_options = self.config_entry.options
-        self.file_name = self.unique_id.split("_")[0].lower()
+        self.file_name = extract_file_name(self.unique_id)
         self._check_alpha = False
         self.number_of_rooms = DEFAULT_ROOMS
         _LOGGER.debug(

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -87,7 +87,7 @@ from .const import (
     ROTATION_VALUES,
     TEXT_SIZE_VALUES,
 )
-from .utils.users_data import (
+from .utils.files_operations import (
     async_del_file,
     async_get_rooms_count,
     async_rename_room_description,

--- a/custom_components/mqtt_vacuum_camera/manifest.json
+++ b/custom_components/mqtt_vacuum_camera/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/sca075/mqtt_vacuum_camera/issues",
     "requirements": ["pillow==10.3.0", "numpy"],
-    "version": "2024.07.2"
+    "version": "2024.07.4b0"
 }

--- a/custom_components/mqtt_vacuum_camera/manifest.json
+++ b/custom_components/mqtt_vacuum_camera/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/sca075/mqtt_vacuum_camera/issues",
     "requirements": ["pillow==10.3.0", "numpy"],
-    "version": "2024.07.4b0"
+    "version": "2024.07.4"
 }

--- a/custom_components/mqtt_vacuum_camera/snapshots/snapshot.py
+++ b/custom_components/mqtt_vacuum_camera/snapshots/snapshot.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.storage import STORAGE_DIR
 from custom_components.mqtt_vacuum_camera.const import CAMERA_STORAGE, DOMAIN
 from custom_components.mqtt_vacuum_camera.types import Any, JsonType, PilPNG
 from custom_components.mqtt_vacuum_camera.utils.files_operations import (
-    async_save_room_data,
     async_write_file_to_disk,
     async_write_json_to_disk,
     async_write_languages_json,
@@ -87,12 +86,6 @@ class Snapshots:
                 self._first_run = False
                 _LOGGER.info(f"Writing {file_name} users languages data.")
                 await async_write_languages_json(self.hass)
-                if await async_save_room_data(
-                    self.storage_path, self.file_name, self._shared.map_rooms
-                ):
-                    _LOGGER.info(f"Rooms data saved for {file_name}.")
-                else:
-                    _LOGGER.info(f"No rooms data save for {file_name}.")
 
             # Save JSON data to a file
             if json_data:

--- a/custom_components/mqtt_vacuum_camera/strings.json
+++ b/custom_components/mqtt_vacuum_camera/strings.json
@@ -151,11 +151,11 @@
           "add_room_1_alpha": "Configure Transparency:"
         },
         "data_description": {
-          "color_room_0": "### **RoomID 16 Entrance**",
-          "color_room_1": "### **RoomID 17 Living Room**",
-          "color_room_2": "### **RoomID 18 Kitchen**",
-          "color_room_3": "### **RoomID 19 Bathroom**",
-          "color_room_4": "### **RoomID 20 Bedroom**",
+          "color_room_0": "Room 1",
+          "color_room_1": "Room 2",
+          "color_room_2": "Room 3",
+          "color_room_3": "Room 4",
+          "color_room_4": "Room 5",
           "color_room_5": "Room 6",
           "color_room_6": "Room 7",
           "color_room_7": "Room 8"

--- a/custom_components/mqtt_vacuum_camera/translations/en.json
+++ b/custom_components/mqtt_vacuum_camera/translations/en.json
@@ -151,11 +151,11 @@
           "add_room_1_alpha": "Configure Transparency:"
         },
         "data_description": {
-          "color_room_0": "### **RoomID 16 Entrance**",
-          "color_room_1": "### **RoomID 17 Living Room**",
-          "color_room_2": "### **RoomID 18 Kitchen**",
-          "color_room_3": "### **RoomID 19 Bathroom**",
-          "color_room_4": "### **RoomID 20 Bedroom**",
+          "color_room_0": "Room 1",
+          "color_room_1": "Room 2",
+          "color_room_2": "Room 3",
+          "color_room_3": "Room 4",
+          "color_room_4": "Room 5",
           "color_room_5": "Room 6",
           "color_room_6": "Room 7",
           "color_room_7": "Room 8"

--- a/custom_components/mqtt_vacuum_camera/types.py
+++ b/custom_components/mqtt_vacuum_camera/types.py
@@ -1,13 +1,18 @@
 """
 This module contains type aliases for the project.
-Version 2024.07.1
+Version 2024.07.4
 """
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, Tuple, Union
 
 from PIL import Image
 import numpy as np
+
+from .const import DEFAULT_ROOMS
+
+_LOGGER = logging.getLogger(__name__)
 
 Color = Union[Tuple[int, int, int], Tuple[int, int, int, int]]
 Colors = Dict[str, Color]
@@ -63,3 +68,30 @@ class TrimCropData:
             trim_right=data[2],
             trim_down=data[3],
         )
+
+
+class RoomStore:
+    """Store the room data for the vacuum."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(RoomStore, cls).__new__(cls)
+            cls._instance.vacuums_data = {}
+        return cls._instance
+
+    def set_rooms_data(self, vacuum_id, rooms_data):
+        """Set the room data for the vacuum."""
+        self.vacuums_data[vacuum_id] = rooms_data
+
+    def get_rooms_data(self, vacuum_id):
+        """Get the room data for a vacuum."""
+        return self.vacuums_data.get(vacuum_id, {})
+
+    def get_rooms_count(self, vacuum_id):
+        """Count the number of rooms for a vacuum."""
+        count = len(self.vacuums_data.get(vacuum_id, {}))
+        if count == 0:
+            return DEFAULT_ROOMS
+        return count

--- a/custom_components/mqtt_vacuum_camera/types.py
+++ b/custom_components/mqtt_vacuum_camera/types.py
@@ -3,6 +3,7 @@ This module contains type aliases for the project.
 Version 2024.07.4
 """
 
+import asyncio
 from dataclasses import dataclass
 import logging
 from typing import Any, Dict, Tuple, Union
@@ -74,6 +75,7 @@ class RoomStore:
     """Store the room data for the vacuum."""
 
     _instance = None
+    _lock = asyncio.Lock()
 
     def __new__(cls):
         if cls._instance is None:
@@ -81,15 +83,15 @@ class RoomStore:
             cls._instance.vacuums_data = {}
         return cls._instance
 
-    def set_rooms_data(self, vacuum_id, rooms_data):
+    async def async_set_rooms_data(self, vacuum_id, rooms_data):
         """Set the room data for the vacuum."""
         self.vacuums_data[vacuum_id] = rooms_data
 
-    def get_rooms_data(self, vacuum_id):
+    async def async_get_rooms_data(self, vacuum_id):
         """Get the room data for a vacuum."""
         return self.vacuums_data.get(vacuum_id, {})
 
-    def get_rooms_count(self, vacuum_id):
+    async def async_get_rooms_count(self, vacuum_id):
         """Count the number of rooms for a vacuum."""
         count = len(self.vacuums_data.get(vacuum_id, {}))
         if count == 0:

--- a/custom_components/mqtt_vacuum_camera/utils/files_operations.py
+++ b/custom_components/mqtt_vacuum_camera/utils/files_operations.py
@@ -1,9 +1,10 @@
 """
+files_operations.py
 Common functions for the MQTT Vacuum Camera integration.
 Those functions are used to store and retrieve user data from the Home Assistant storage.
 The data will be stored locally in the Home Assistant in .storage/valetudo_camera directory.
 Author: @sca075
-Version: 2024.07.2
+Version: 2024.07.4
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ import glob
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Optional, Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
@@ -24,8 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_get_rooms_count(
-    hass: HomeAssistant,
-    robot_name: str,
+        hass: HomeAssistant,
+        robot_name: str,
 ) -> int:
     """Get the number of segments in the room_data_{vacuum_id}.json file."""
     file_path = hass.config.path(
@@ -114,7 +115,7 @@ async def async_find_last_logged_in_user(hass: HomeAssistant) -> str or None:
         # Iterate through refresh tokens to find the most recent usage
         for token in user.refresh_tokens.values():
             if token.last_used_at and (
-                last_login_time is None or token.last_used_at > last_login_time
+                    last_login_time is None or token.last_used_at > last_login_time
             ):
                 last_login_time = token.last_used_at
                 last_user = user
@@ -240,7 +241,7 @@ async def async_load_languages(storage_path: str, selected_languages=None) -> li
 
 
 async def async_load_translations_json(
-    hass: HomeAssistant, languages: list[str]
+        hass: HomeAssistant, languages: list[str]
 ) -> list[Optional[dict]]:
     """
     Load the user selected language json files and return them as a list of JSON objects.
@@ -280,7 +281,7 @@ async def async_load_room_data(storage_path: str, vacuum_id: str) -> dict:
 
 
 async def async_rename_room_description(
-    hass: HomeAssistant, storage_path: str, vacuum_id: str
+        hass: HomeAssistant, storage_path: str, vacuum_id: str
 ) -> bool:
     """
     Add room names to the room descriptions in the translations.
@@ -363,10 +364,9 @@ async def async_del_file(file):
 
 
 async def async_write_file_to_disk(
-    file_to_write: str, data, is_binary: bool = False
+        file_to_write: str, data, is_binary: bool = False
 ) -> None:
     """Asynchronously write data to a file."""
-    loop = asyncio.get_event_loop()
 
     def _write_to_file(file_path, data_to_write, binary_mode):
         """Helper function to write data to a file."""
@@ -378,14 +378,13 @@ async def async_write_file_to_disk(
                 datafile.write(data_to_write)
 
     try:
-        await loop.run_in_executor(None, _write_to_file, file_to_write, data, is_binary)
+        await asyncio.to_thread(_write_to_file, file_to_write, data, is_binary)
     except OSError as e:
         _LOGGER.warning(f"Blocking issue detected: {e}")
 
 
 async def async_write_json_to_disk(file_to_write: str, json_data) -> None:
     """Asynchronously write data to a JSON file."""
-    loop = asyncio.get_event_loop()
 
     def _write_to_file(file_path, data):
         """Helper function to write data to a file."""
@@ -393,14 +392,13 @@ async def async_write_json_to_disk(file_to_write: str, json_data) -> None:
             json.dump(data, datafile, indent=2)
 
     try:
-        await loop.run_in_executor(None, _write_to_file, file_to_write, json_data)
+        await asyncio.to_thread(_write_to_file, file_to_write, json_data)
     except OSError as e:
         _LOGGER.warning(f"Blocking issue detected: {e}")
 
 
 async def async_load_file(file_to_load: str, is_json: bool = False) -> Any:
     """Asynchronously load JSON data from a file."""
-    loop = asyncio.get_event_loop()
 
     def read_file(my_file: str, read_json: bool = False):
         """Helper function to read data from a file."""
@@ -416,7 +414,7 @@ async def async_load_file(file_to_load: str, is_json: bool = False) -> Any:
             return None
 
     try:
-        return await loop.run_in_executor(None, read_file, file_to_load, is_json)
+        return await asyncio.to_thread(read_file, file_to_load, is_json)
     except (FileNotFoundError, json.JSONDecodeError) as e:
         _LOGGER.warning(f"Blocking IO issue detected: {e}")
         return None
@@ -425,7 +423,9 @@ async def async_load_file(file_to_load: str, is_json: bool = False) -> Any:
 async def async_save_room_data(storage_path, file_name, map_rooms) -> bool:
     """Get the Vacuum Rooms data and save it to a file."""
     # New file room_data to be saved / updated
-    data_file_path = os.path.join(storage_path, f"room_data_{file_name}.json")
+    data_file_path = os.path.join(
+        storage_path, f"room_data_{file_name}.json"
+    )
     un_formated_room_data = map_rooms
     if not un_formated_room_data:
         return False
@@ -439,7 +439,8 @@ async def async_save_room_data(storage_path, file_name, map_rooms) -> bool:
                 }
             #### Logger to be removed after testing ####
             _LOGGER.debug(
-                f">>>>>>> Number of Segments detected:" f" {len(un_formated_room_data)}"
+                f">>>>>>> Number of Segments detected:"
+                f" {len(un_formated_room_data)}"
             )
             if len(un_formated_room_data) >= 1:
                 await async_write_json_to_disk(data_file_path, room_data)

--- a/custom_components/mqtt_vacuum_camera/utils/files_operations.py
+++ b/custom_components/mqtt_vacuum_camera/utils/files_operations.py
@@ -19,34 +19,15 @@ from typing import Any, Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from custom_components.mqtt_vacuum_camera.const import CAMERA_STORAGE, DEFAULT_ROOMS
+from custom_components.mqtt_vacuum_camera.const import CAMERA_STORAGE
 from custom_components.mqtt_vacuum_camera.types import RoomStore
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_get_rooms_count(
-    hass: HomeAssistant,
-    robot_name: str,
-) -> int:
-    """Get the number of segments in the room_data_{vacuum_id}.json file."""
-    file_path = hass.config.path(
-        STORAGE_DIR, CAMERA_STORAGE, f"room_data_{robot_name}.json"
-    )
-    if not os.path.exists(file_path):
-        _LOGGER.warning(f"File not found: {file_path}")
-        return DEFAULT_ROOMS
-    else:
-        room_data = await async_load_file(file_path, True)
-        if room_data:
-            room_count = room_data.get("segments", DEFAULT_ROOMS)
-            return room_count
-        else:
-            _LOGGER.error(f"Error decoding file: {file_path}")
-            return DEFAULT_ROOMS
-
-
-async def async_write_vacuum_id(hass: HomeAssistant, file_name, vacuum_id):
+async def async_write_vacuum_id(
+    hass: HomeAssistant, file_name: str, vacuum_id: str
+) -> None:
     """Write the vacuum_id to a JSON file."""
     # Create the full file path
     if vacuum_id:
@@ -60,9 +41,11 @@ async def async_write_vacuum_id(hass: HomeAssistant, file_name, vacuum_id):
             _LOGGER.info(f"vacuum_id saved: {vacuum_id}")
         else:
             _LOGGER.warning(f"Error saving vacuum_id: {vacuum_id}")
+    else:
+        _LOGGER.warning("No vacuum_id provided.")
 
 
-async def async_get_translations_vacuum_id(storage_dir):
+async def async_get_translations_vacuum_id(storage_dir: str) -> str or None:
     """Read the vacuum_id from a JSON file."""
     # Create the full file path
     vacuum_id_path = os.path.join(storage_dir, "rooms_colours_description.json")
@@ -227,7 +210,9 @@ async def async_write_languages_json(hass: HomeAssistant):
 
 
 async def async_load_languages(storage_path: str, selected_languages=None) -> list:
-    """Load the selected language from the language.json file."""
+    """
+    Load the selected language from the language.json file.
+    """
     if selected_languages is None:
         selected_languages = []
     language_file_path = os.path.join(storage_path, "languages.json")
@@ -253,9 +238,6 @@ async def async_load_translations_json(
 ) -> list[Optional[dict]]:
     """
     Load the user selected language json files and return them as a list of JSON objects.
-    @param hass: Home Assistant instance.
-    @param languages: List of languages to load.
-    @return: List of JSON objects containing translations for each language.
     """
     translations_list = []
     translations_path = hass.config.path(
@@ -295,7 +277,7 @@ async def async_rename_room_description(
     Add room names to the room descriptions in the translations.
     """
     # Load the room data using the new MQTT-based function
-    room_data = RoomStore().get_rooms_data(vacuum_id)
+    room_data = await RoomStore().async_get_rooms_data(vacuum_id)
     _LOGGER.info(f"Room data loaded: {room_data}")
 
     if not room_data:
@@ -376,7 +358,9 @@ async def async_del_file(file):
 async def async_write_file_to_disk(
     file_to_write: str, data, is_binary: bool = False
 ) -> None:
-    """Asynchronously write data to a file."""
+    """
+    Asynchronously write data to a file.
+    """
 
     def _write_to_file(file_path, data_to_write, binary_mode):
         """Helper function to write data to a file."""
@@ -389,8 +373,10 @@ async def async_write_file_to_disk(
 
     try:
         await asyncio.to_thread(_write_to_file, file_to_write, data, is_binary)
+    except (OSError, IOError) as e:
+        _LOGGER.warning(f"Error on writing data to disk.: {e}")
     except Exception as e:
-        _LOGGER.warning(f"Blocking issue detected: {e}")
+        _LOGGER.warning(f"Unexpected issue detected: {e}")
 
 
 async def async_write_json_to_disk(file_to_write: str, json_data) -> None:
@@ -403,6 +389,8 @@ async def async_write_json_to_disk(file_to_write: str, json_data) -> None:
 
     try:
         await asyncio.to_thread(_write_to_file, file_to_write, json_data)
+    except (OSError, IOError, json.JSONDecodeError) as e:
+        _LOGGER.warning(f"Json File Operation Error: {e}")
     except Exception as e:
         _LOGGER.warning(f"Blocking issue detected: {e}")
 

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -5,6 +5,7 @@ Version: v2024.07.1
 - Added gzip library used in Valetudo RE data compression.
 """
 
+import logging
 import asyncio
 import json
 
@@ -14,8 +15,9 @@ from homeassistant.helpers.storage import STORAGE_DIR
 from isal import igzip, isal_zlib
 
 from custom_components.mqtt_vacuum_camera.common import async_write_file_to_disk
-from custom_components.mqtt_vacuum_camera.const import _LOGGER
 from custom_components.mqtt_vacuum_camera.valetudo.rand256.rrparser import RRMapParser
+
+_LOGGER = logging.getLogger(__name__)
 
 _QOS = 0
 

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -14,7 +14,9 @@ from homeassistant.core import callback
 from homeassistant.helpers.storage import STORAGE_DIR
 from isal import igzip, isal_zlib
 
-from custom_components.mqtt_vacuum_camera.common import async_write_file_to_disk
+from custom_components.mqtt_vacuum_camera.utils.files_operations import (
+    async_write_file_to_disk,
+)
 from custom_components.mqtt_vacuum_camera.valetudo.rand256.rrparser import RRMapParser
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -1,13 +1,13 @@
 """
-Version: v2024.07.1
+Version: v2024.07.2
 - Removed the PNG decode, the json is extracted from map-data instead of map-data-hass.
 - Tested no influence on the camera performance.
 - Added gzip library used in Valetudo RE data compression.
 """
 
-import logging
 import asyncio
 import json
+import logging
 
 from homeassistant.components import mqtt
 from homeassistant.core import callback

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -36,6 +36,7 @@ class ValetudoConnector:
         self._payload = None
         self._img_payload = None
         self._mqtt_vac_stat = ""
+        self._mqtt_segments = {}
         self._mqtt_vac_connect_state = "disconnected"
         self._mqtt_vac_battery_level = None
         self._mqtt_vac_err = None
@@ -129,6 +130,10 @@ class ValetudoConnector:
     async def is_data_available(self) -> bool:
         """Check and Return the data availability."""
         return bool(self._data_in)
+
+    def get_segments(self) -> dict:
+        """Return the segments."""
+        return dict(self._mqtt_segments)
 
     @callback
     async def save_payload(self, file_name: str) -> None:
@@ -341,12 +346,16 @@ class ValetudoConnector:
             await self.rrm_handle_active_segments(msg)
         elif self._rcv_topic == f"{self._mqtt_topic}/destinations":
             await self._hass.async_create_task(self.rand256_handle_destinations(msg))
+        elif self._rcv_topic == f"{self._mqtt_topic}/MapData/segments":
+            self._mqtt_segments = json.loads(msg.payload)
+            _LOGGER.debug(f"Segments: {self._mqtt_segments}")
 
     async def async_subscribe_to_topics(self) -> None:
         """Subscribe to the MQTT topics for Hypfer and ValetudoRe."""
         if self._mqtt_topic:
             for x in [
                 f"{self._mqtt_topic}/MapData/map-data",
+                f"{self._mqtt_topic}/MapData/segments",
                 f"{self._mqtt_topic}/StatusStateAttribute/status",
                 f"{self._mqtt_topic}/StatusStateAttribute/error_description",
                 f"{self._mqtt_topic}/$state",

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -14,6 +14,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.storage import STORAGE_DIR
 from isal import igzip, isal_zlib
 
+from custom_components.mqtt_vacuum_camera.types import RoomStore
 from custom_components.mqtt_vacuum_camera.utils.files_operations import (
     async_write_file_to_disk,
 )
@@ -348,6 +349,7 @@ class ValetudoConnector:
             await self._hass.async_create_task(self.rand256_handle_destinations(msg))
         elif self._rcv_topic == f"{self._mqtt_topic}/MapData/segments":
             self._mqtt_segments = json.loads(msg.payload)
+            RoomStore().set_rooms_data(self._file_name, self._mqtt_segments)
             _LOGGER.debug(f"Segments: {self._mqtt_segments}")
 
     async def async_subscribe_to_topics(self) -> None:

--- a/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
@@ -15,10 +15,6 @@ from PIL import Image, ImageOps
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from custom_components.mqtt_vacuum_camera.common import (
-    async_load_file,
-    async_write_json_to_disk,
-)
 from custom_components.mqtt_vacuum_camera.const import CAMERA_STORAGE
 from custom_components.mqtt_vacuum_camera.types import (
     CalibrationPoints,
@@ -32,6 +28,10 @@ from custom_components.mqtt_vacuum_camera.types import (
 )
 from custom_components.mqtt_vacuum_camera.utils.colors_man import color_grey
 from custom_components.mqtt_vacuum_camera.utils.drawable import Drawable
+from custom_components.mqtt_vacuum_camera.utils.files_operations import (
+    async_load_file,
+    async_write_json_to_disk,
+)
 from custom_components.mqtt_vacuum_camera.utils.img_data import ImageData
 from custom_components.mqtt_vacuum_camera.valetudo.hypfer.handler_utils import (
     ImageUtils as ImUtils,


### PR DESCRIPTION
The file_name of the rooms_data was miss extracted as per there was a split function for "_" that is commonly used in the entity_ids in Home Assistant. As consequence some of the vacuums renamed from users can have issues confirguring the vacuum maps. 

This PR is to solve this issue.  As well to improve the code orgnaization some additional commit will be issue, in order to put alall files managments functions in one module only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced filename extraction for improved configuration.
  - Introduced asynchronous methods for file and JSON operations.
  - Added a singleton class for managing vacuum room data with enhanced functionalities.

- **Bug Fixes**
  - Improved handling of room data storage with error handling.
  - Updated component version to address minor issues.

- **Refactor**
  - Reorganized import paths for cleaner code structure.
  - Simplified initialization logic for better maintainability.

- **Documentation**
  - Updated docstrings to reflect new functionalities.

- **Chores**
  - Incremented version numbers to align with recent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->