### PR TITLE
Dependencies updated pillow version. 

### DIFF
--- a/custom_components/mqtt_vacuum_camera/manifest.json
+++ b/custom_components/mqtt_vacuum_camera/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/sca075/mqtt_vacuum_camera",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/sca075/mqtt_vacuum_camera/issues",
-    "requirements": ["pillow==10.3.0", "numpy"],
-    "version": "2024.08.0b0"
+    "requirements": ["pillow==10.4.0", "numpy"],
+    "version": "2024.08.0b1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "MQTT Vacuum Camera",
   "zip_release": true,
   "render_readme": true,
-  "homeassistant": "2024.6.0",
+  "homeassistant": "2024.8.0b1",
   "filename": "mqtt_vacuum_camera.zip"
 }


### PR DESCRIPTION
Deprecations
BGR;15, BGR 16 and BGR;24
The experimental BGR;15, BGR;16 and BGR;24 modes have been deprecated.

Non-image modes in ImageCms
The use in [ImageCms](https://pillow.readthedocs.io/en/stable/reference/ImageCms.html#module-PIL.ImageCms) of input modes and output modes that are not Pillow image modes has been deprecated. Defaulting to “L” or “1” if the mode cannot be mapped is also deprecated.

Support for LibTIFF earlier than 4
Support for LibTIFF earlier than version 4 has been deprecated. Upgrade to a newer version of LibTIFF instead.

ImageDraw.getdraw hints parameter
The hints parameter in [getdraw()](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.getdraw) has been deprecated.

API Additions
ImageDraw.circle
Added [circle()](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.circle). It provides the same functionality as [ellipse()](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.ellipse), but instead of taking a bounding box, it takes a center point and radius.

Other Changes
Python 3.13 beta
To help others prepare for Python 3.13, wheels have been built against the 3.13 beta as a preview. This is not official support for Python 3.13, but simply an opportunity for users to test how Pillow works with the beta and report any problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `mqtt_vacuum_camera` component to version `2024.08.0b1`.
- **Bug Fixes**
	- Upgraded the `pillow` library to version `10.4.0`, likely resolving issues and improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->