### PR TITLE
Fix fo #278 

### DIFF
--- a/custom_components/mqtt_vacuum_camera/common.py
+++ b/custom_components/mqtt_vacuum_camera/common.py
@@ -99,6 +99,9 @@ def get_vacuum_unique_id_from_mqtt_topic(vacuum_mqtt_topic: str) -> str:
     """
     Returns the unique_id computed from the mqtt_topic for the vacuum.
     """
+    if not vacuum_mqtt_topic or "/" not in vacuum_mqtt_topic:
+        raise ValueError("Invalid MQTT topic format")
+
     return vacuum_mqtt_topic.split("/")[1].lower() + "_camera"
 
 

--- a/custom_components/mqtt_vacuum_camera/config_flow.py
+++ b/custom_components/mqtt_vacuum_camera/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant import config_entries
 from homeassistant.components.vacuum import DOMAIN as ZONE_VACUUM
 from homeassistant.const import CONF_UNIQUE_ID
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import entity_registry as er
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
@@ -114,10 +115,13 @@ class MQTTCameraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vacuum_entity_id = user_input["vacuum_entity"]
             entity_registry = er.async_get(self.hass)
             vacuum_entity = entity_registry.async_get(vacuum_entity_id)
+            vacuum_topic = get_vacuum_mqtt_topic(vacuum_entity_id, self.hass)
+            if not vacuum_topic:
+                raise ConfigEntryError(
+                    f"Vacuum {vacuum_entity_id} not supported! No MQTT topic found."
+                )
 
-            unique_id = get_vacuum_unique_id_from_mqtt_topic(
-                get_vacuum_mqtt_topic(vacuum_entity_id, self.hass)
-            )
+            unique_id = get_vacuum_unique_id_from_mqtt_topic(vacuum_topic)
 
             for existing_entity in self._async_current_entries():
                 if (


### PR DESCRIPTION
Fix issue #278  adding in config_flow logic to detect if the vacuum is actually using MQTT. If not will raise ConfigEntryError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for MQTT topics in vacuum configuration.
	- Improved logic for retrieving unique IDs based on validated MQTT topics.

- **Bug Fixes**
	- Added validation checks to ensure only valid MQTT topics are processed.
	- Refined entity ID collection to ensure completeness.

- **Documentation**
	- Updated error reporting for option migrations to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->