### PR TITLE
Adding event "valetudo_error"

### DIFF
--- a/custom_components/mqtt_vacuum_camera/utils/drawable.py
+++ b/custom_components/mqtt_vacuum_camera/utils/drawable.py
@@ -399,7 +399,7 @@ class Drawable:
         y: int,
         angle: float,
         fill: Color,
-        robot_state: str = None,
+        robot_state: str | None = None,
     ) -> NumpyArray:
         """
         We Draw the robot with in a smaller array

--- a/custom_components/mqtt_vacuum_camera/utils/drawable.py
+++ b/custom_components/mqtt_vacuum_camera/utils/drawable.py
@@ -3,7 +3,7 @@ Collections of Drawing Utility
 Drawable is part of the Image_Handler
 used functions to draw the elements on the Numpy Array
 that is actually our camera frame.
-Version: v2024.11.0
+Version: v2024.12.0
 """
 
 from __future__ import annotations
@@ -399,6 +399,7 @@ class Drawable:
         y: int,
         angle: float,
         fill: Color,
+        robot_state: str = None,
     ) -> NumpyArray:
         """
         We Draw the robot with in a smaller array
@@ -424,7 +425,10 @@ class Drawable:
         r_lidar = r_scaled * 3  # Scale factor for the lidar
         r_button = r_scaled * 1  # scale factor of the button
         # Outline colour from fill colour
-        outline = (fill[0] // 2, fill[1] // 2, fill[2] // 2, fill[3])
+        if robot_state == "error":
+            outline = (255, 0, 0, fill[3])
+        else:
+            outline = (fill[0] // 2, fill[1] // 2, fill[2] // 2, fill[3])
         # Draw the robot outline
         tmp_layer = Drawable._filled_circle(
             tmp_layer, (tmp_x, tmp_y), radius, fill, outline, 1

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -112,6 +112,7 @@ class ValetudoConnector:
     async def get_vacuum_status(self) -> str:
         """Return the vacuum status."""
         if (self._mqtt_vac_stat == "error") or (self._mqtt_vac_re_stat == "error"):
+            # Fire the valetudo_error event when an error is detected
             self._hass.bus.async_fire(
                 "valetudo_error",
                 {"entity_id": f"vacuum.{self._file_name}", "error": self._mqtt_vac_err},
@@ -224,12 +225,6 @@ class ValetudoConnector:
         """
         self._mqtt_vac_err = errors
         _LOGGER.info(f"{self._mqtt_topic}: Received vacuum Error: {self._mqtt_vac_err}")
-        # Fire the valetudo_error event when an error is detected
-        self._hass.bus.async_fire(
-            "valetudo_error",
-            {"entity_id": f"vacuum.{self._file_name}", "error": self._mqtt_vac_err},
-            EventOrigin.local,
-        )
 
     async def hypfer_handle_battery_level(self, battery_state) -> None:
         """

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -216,6 +216,12 @@ class ValetudoConnector:
         /StatusStateAttribute/error_description is for Hypfer.
         """
         self._mqtt_vac_err = errors
+        # Fire the valetudo_error event when an error is detected
+        self._hass.bus.async_fire(
+            "valetudo_error",
+            {"entity_id": f"mqtt_vacuum.{self._file_name}", "error": self._mqtt_vac_err},
+            EventOrigin.local,
+        )
         _LOGGER.info(f"{self._mqtt_topic}: Received vacuum Error: {self._mqtt_vac_err}")
 
     async def hypfer_handle_battery_level(self, battery_state) -> None:

--- a/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/MQTT/connector.py
@@ -1,5 +1,5 @@
 """
-Version: v2024.11.0
+Version: v2024.12.0
 """
 
 import asyncio

--- a/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
@@ -234,6 +234,7 @@ class MapImageHandler(object):
                 if self.shared.vacuum_state == "docked":
                     # Adjust the robot angle.
                     robot_position_angle -= 180
+
                 if robot_pos:
                     # Draw the robot
                     img_np_array = await self.draw.robot(
@@ -242,6 +243,7 @@ class MapImageHandler(object):
                         y=robot_position[1],
                         angle=robot_position_angle,
                         fill=colors["robot"],
+                        robot_state=self.shared.vacuum_state,
                     )
                 # Resize the image
                 img_np_array = await self.ac.async_auto_trim_and_zoom_image(

--- a/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/hypfer/image_handler.py
@@ -2,7 +2,7 @@
 Hypfer Image Handler Class.
 It returns the PIL PNG image frame relative to the Map Data extrapolated from the vacuum json.
 It also returns calibration, rooms data to the card and other images information to the camera.
-Version: 2024.11.1
+Version: 2024.12.0
 """
 
 from __future__ import annotations

--- a/custom_components/mqtt_vacuum_camera/valetudo/rand256/reimg_draw.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/rand256/reimg_draw.py
@@ -1,7 +1,7 @@
 """
 Image Draw Class for Valetudo Rand256 Image Handling.
 This class is used to simplify the ImageHandler class.
-Version: 2024.11.1
+Version: 2024.12.0
 """
 
 from __future__ import annotations

--- a/custom_components/mqtt_vacuum_camera/valetudo/rand256/reimg_draw.py
+++ b/custom_components/mqtt_vacuum_camera/valetudo/rand256/reimg_draw.py
@@ -361,10 +361,11 @@ class ImageDraw:
         """Draw the robot on the map."""
         if robot_pos and robot_angle:
             np_array = await self.draw.robot(
-                np_array,
-                robot_pos[0],
-                robot_pos[1],
-                robot_angle,
-                color_robot,
+                layers=np_array,
+                x=robot_pos[0],
+                y=robot_pos[1],
+                angle=robot_angle,
+                fill=color_robot,
+                robot_state=self.img_h.shared.vacuum_state,
             )
         return np_array


### PR DESCRIPTION
When a vacuum error is generated we generate an event in order to trigger automations or scripts to execute a user programmed notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced error handling with the firing of a `valetudo_error` event for better error reporting.
	- Added a visual representation change for the robot based on its state (e.g., outline color changes to red on error).
	- Improved image generation logic to accurately reflect the robot's orientation and state.

- **Bug Fixes**
	- Updated error handling in image generation to provide more robust logging.

- **Documentation**
	- Updated method signatures for clarity and consistency in the ValetudoConnector and Drawable classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->