### PR TITLE
fix issue #282 AREA_SQUARE_METERS deprecated

### DIFF
--- a/custom_components/mqtt_vacuum_camera/sensor.py
+++ b/custom_components/mqtt_vacuum_camera/sensor.py
@@ -1,5 +1,5 @@
 """Sensors for Rand256.
-Version 2024.11.0
+Version 2024.12.0
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import AREA_SQUARE_METERS, PERCENTAGE, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfTime, UnitOfArea
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import EntityCategory
@@ -81,7 +81,7 @@ SENSOR_TYPES = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "current_clean_area": VacuumSensorDescription(
-        native_unit_of_measurement=AREA_SQUARE_METERS,
+        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         key="currentCleanArea",
         icon="mdi:texture-box",
         name="Current clean area",
@@ -133,7 +133,7 @@ SENSOR_TYPES = {
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "last_run_area": VacuumSensorDescription(
-        native_unit_of_measurement=AREA_SQUARE_METERS,
+        native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         key="last_run_area",
         icon="mdi:texture-box",
         name="Last run area",


### PR DESCRIPTION
Beta testing Home Assistant 2024.12.0b0 of home assistant warning of usage Beta testing new 2024.12.0b0 of home assistant warning of AREA_SQUARE_METERS constant deprecation popped put. To comply the UnitOfArea data type is used instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version to 2024.12.0 for improved functionality.
	- Enhanced sensor readings with updated measurement units for area-related sensors. 

These changes ensure more accurate data representation for the current cleaning area and last run area in the vacuum camera component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->