### PR TITLE
Outer Robot lines to Black

### DIFF
--- a/custom_components/mqtt_vacuum_camera/utils/drawable.py
+++ b/custom_components/mqtt_vacuum_camera/utils/drawable.py
@@ -22,7 +22,7 @@ class Drawable:
     This class contains static methods to draw various elements on the Numpy Arrays (images).
     We cant use openCV because it is not supported by the Home Assistant OS.
     """
-    ERROR_OUTLINE = (255, 0, 0, 255)  # Red color for error messages
+    ERROR_OUTLINE = (0, 0, 0, 255)  # Red color for error messages
     ERROR_COLOR = (255, 0, 0, 191)  # Red color with lower opacity for error outlines
     @staticmethod
     async def create_empty_image(


### PR DESCRIPTION
In Case of Error the color of the robot changes. The red outbound was not visible. We changed it to black.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the error outline color from red to black for improved visual representation in drawing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->