### PR TITLE
fixed wrong version

### DIFF
--- a/custom_components/mqtt_vacuum_camera/manifest.json
+++ b/custom_components/mqtt_vacuum_camera/manifest.json
@@ -11,5 +11,5 @@
         "pillow>=10.3.0,<=11.5.0",
         "numpy>=1.26.4",
         "valetudo_map_parser==0.1.9.b23"],
-    "version": "2024.2.0"
+    "version": "2025.2.0"
 }


### PR DESCRIPTION
HACS can’t update download due to typo in version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Released a new version of the MQTT Vacuum Camera component (version 2025.2.0) to reflect an updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->