### PR TITLE
Initialize last_loaded_map

### DIFF
--- a/custom_components/mqtt_vacuum_camera/coordinator.py
+++ b/custom_components/mqtt_vacuum_camera/coordinator.py
@@ -146,12 +146,12 @@ class MQTTVacuumCoordinator(DataUpdateCoordinator):
                 vacuum_state = await self.connector.get_vacuum_status()
                 vacuum_room = self.shared.current_room
                 last_run_stats = sensor_data.get("last_run_stats", {})
-                last_loaded_map = sensor_data.get("last_loaded_map", {})
+                last_loaded_map = sensor_data.get("last_loaded_map", {"name": "Default"})
 
                 if not vacuum_room:
                     vacuum_room = {"in_room": "Unsupported"}
-                if last_loaded_map == {}:
-                    last_loaded_map = {"name", "Default"}
+                if not last_loaded_map:
+                    last_loaded_map = {"name": "Default"}
 
                 formatted_data = {
                     "mainBrush": sensor_data.get("mainBrush", 0),


### PR DESCRIPTION
initialize "last_loaded_map" if None to get rid of "'NoneType' object has no attribute 'get'" warning.
Fix #324 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sensor data processing to consistently present default mapping information when actual data is missing. This enhancement ensures a more reliable and stable display by supplying a preset value when the expected sensor data isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->