### PR TITLE
feat: add floor selection services and bump version to 2026.4.0 

### DIFF
--- a/custom_components/mqtt_vacuum_camera/__init__.py
+++ b/custom_components/mqtt_vacuum_camera/__init__.py
@@ -42,6 +42,8 @@ from .const import (
 from .coordinator import MQTTVacuumCoordinator
 from .types import CoordinatorConfig
 from .utils.camera.camera_services import (
+    camera_select_floor,
+    camera_update_floor_data,
     obstacle_view,
     reload_camera_config,
     reset_trims,
@@ -166,6 +168,12 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
         hass.services.async_register(
             DOMAIN, "obstacle_view", partial(obstacle_view, hass=hass)
         )
+        hass.services.async_register(
+            DOMAIN, "camera_select_floor", partial(camera_select_floor, hass=hass)
+        )
+        hass.services.async_register(
+            DOMAIN, "camera_update_floor_data", partial(camera_update_floor_data, hass=hass)
+        )
         await async_register_vacuums_services(hass, data_coordinator)
     # Registers update listener to update config entry when options are updated.
     unsub_options_update_listener = entry.add_update_listener(options_update_listener)
@@ -219,6 +227,8 @@ async def async_unload_entry(
         if not hass.data[DOMAIN]:
             hass.services.async_remove(DOMAIN, "reset_trims")
             hass.services.async_remove(DOMAIN, "obstacle_view")
+            hass.services.async_remove(DOMAIN, "camera_select_floor")
+            hass.services.async_remove(DOMAIN, "camera_update_floor_data")
             hass.services.async_remove(DOMAIN, SERVICE_RELOAD)
             await async_remove_vacuums_services(hass)
     return unload_ok

--- a/custom_components/mqtt_vacuum_camera/manifest.json
+++ b/custom_components/mqtt_vacuum_camera/manifest.json
@@ -11,5 +11,5 @@
     "issue_tracker": "https://github.com/sca075/mqtt_vacuum_camera/issues",
     "loggers": ["mqtt_vacuum_camera"],
     "requirements": ["valetudo_map_parser==0.3.3"],
-    "version": "2026.3.1"
+    "version": "2026.4.0"
 }

--- a/custom_components/mqtt_vacuum_camera/services.yaml
+++ b/custom_components/mqtt_vacuum_camera/services.yaml
@@ -164,3 +164,31 @@ vacuum_map_load:
       example: "My map"
       selector:
         text:
+
+camera_select_floor:
+  name: Camera select floor
+  description: Select the active floor for a camera entity. The floor must already be configured in the integration options.
+  target:
+    entity:
+      domain: camera
+  fields:
+    floor_id:
+      name: Floor
+      description: The floor to set as active (must match a configured floor).
+      required: true
+      selector:
+        floor:
+
+camera_update_floor_data:
+  name: Camera update floor data
+  description: Save the current auto-calculated map trims into the active floor's configuration.
+  target:
+    entity:
+      domain: camera
+  fields:
+    floor_id:
+      name: Floor
+      description: Optional floor to update. Defaults to the currently active floor.
+      required: false
+      selector:
+        floor:

--- a/custom_components/mqtt_vacuum_camera/utils/camera/camera_services.py
+++ b/custom_components/mqtt_vacuum_camera/utils/camera/camera_services.py
@@ -3,9 +3,10 @@
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import entity_registry as er
 
-from ...common import get_entity_id
-from ...const import DOMAIN, LOGGER
+from ...common import create_floor_data, get_entity_id
+from ...const import CONF_CURRENT_FLOOR, CONF_FLOORS_DATA, DOMAIN, LOGGER
 from ...utils.files_operations import async_clean_up_all_auto_crop_files
 
 
@@ -76,5 +77,108 @@ async def obstacle_view(call: ServiceCall, hass: HomeAssistant) -> None:
             "entity_id": camera_entity_id,
             "coordinates": {"x": coordinates_x, "y": coordinates_y},
         },
+        context=call.context,
+    )
+
+
+def _get_config_entry_from_camera(
+    camera_entity_id: str, hass: HomeAssistant
+):
+    """Return the ConfigEntry for a camera entity_id, or None if not found."""
+    entity_reg = er.async_get(hass)
+    entity_entry = entity_reg.async_get(camera_entity_id)
+    if not entity_entry or not entity_entry.config_entry_id:
+        LOGGER.warning("Camera entity %s not found in entity registry", camera_entity_id)
+        return None
+    entry = hass.config_entries.async_get_entry(entity_entry.config_entry_id)
+    if not entry:
+        LOGGER.warning("Config entry not found for camera %s", camera_entity_id)
+    return entry
+
+
+def _resolve_camera_entity_id(call: ServiceCall, hass: HomeAssistant) -> str | None:
+    """Resolve the first camera entity_id from a service call."""
+    entity_id = call.data.get("entity_id")
+    device_id = call.data.get("device_id")
+    resolved = get_entity_id(entity_id, device_id, hass, "camera")
+    if not resolved:
+        LOGGER.warning("Could not resolve camera entity from service call")
+        return None
+    return resolved[0] if isinstance(resolved, list) else resolved
+
+
+async def camera_select_floor(call: ServiceCall, hass: HomeAssistant) -> None:
+    """Select the active floor for a camera entity."""
+    floor_id = call.data.get("floor_id")
+    if not floor_id:
+        LOGGER.warning("camera_select_floor: floor_id is required")
+        return
+
+    camera_entity_id = _resolve_camera_entity_id(call, hass)
+    if not camera_entity_id:
+        return
+
+    entry = _get_config_entry_from_camera(camera_entity_id, hass)
+    if not entry:
+        return
+
+    floors_data = entry.options.get(CONF_FLOORS_DATA, {})
+    if floors_data and floor_id not in floors_data:
+        LOGGER.warning(
+            "camera_select_floor: floor_id '%s' is not configured for %s",
+            floor_id,
+            camera_entity_id,
+        )
+        return
+
+    updated_options = {**entry.options, CONF_CURRENT_FLOOR: floor_id}
+    hass.config_entries.async_update_entry(entry, options=updated_options)
+    hass.bus.async_fire(
+        f"event_{DOMAIN}_floor_selected",
+        {"entity_id": camera_entity_id, "floor_id": floor_id},
+        context=call.context,
+    )
+
+
+async def camera_update_floor_data(call: ServiceCall, hass: HomeAssistant) -> None:
+    """Save current auto-calculated trims into the active floor's FloorData."""
+    camera_entity_id = _resolve_camera_entity_id(call, hass)
+    if not camera_entity_id:
+        return
+
+    entry = _get_config_entry_from_camera(camera_entity_id, hass)
+    if not entry:
+        return
+
+    hass_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinator = hass_data.get("coordinator")
+    if not coordinator:
+        LOGGER.warning("camera_update_floor_data: coordinator not available for %s", camera_entity_id)
+        return
+
+    floor_id = call.data.get("floor_id") or entry.options.get(CONF_CURRENT_FLOOR, "floor_0")
+    floors_data = dict(entry.options.get(CONF_FLOORS_DATA, {}))
+    floor_data_dict = floors_data.get(floor_id, {})
+
+    trims_dict = coordinator.context.shared.trims.to_dict()
+    updated_floor = create_floor_data(
+        floor_name=floor_id,
+        trim_up=trims_dict.get("trim_up", 0),
+        trim_down=trims_dict.get("trim_down", 0),
+        trim_left=trims_dict.get("trim_left", 0),
+        trim_right=trims_dict.get("trim_right", 0),
+        map_name=floor_data_dict.get("map_name", ""),
+    )
+
+    floors_data[floor_id] = updated_floor.to_dict()
+    updated_options = {
+        **entry.options,
+        CONF_FLOORS_DATA: floors_data,
+        "trims_data": updated_floor.trims.to_dict(),
+    }
+    hass.config_entries.async_update_entry(entry, options=updated_options)
+    hass.bus.async_fire(
+        f"event_{DOMAIN}_floor_data_updated",
+        {"entity_id": camera_entity_id, "floor_id": floor_id},
         context=call.context,
     )

--- a/custom_components/mqtt_vacuum_camera/utils/connection/connector.py
+++ b/custom_components/mqtt_vacuum_camera/utils/connection/connector.py
@@ -3,13 +3,13 @@ Consolidated ValetudoConnector with grouped data.
 Last Updated on version: 2025.10.0
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List
 
 from homeassistant.components import mqtt, persistent_notification
 from homeassistant.core import EventOrigin, HomeAssistant, callback
-from homeassistant.helpers.event import async_track_state_change_event
 from valetudo_map_parser.config.types import RoomStore
 
 from custom_components.mqtt_vacuum_camera.common import (
@@ -156,7 +156,7 @@ class ValetudoConnector:
         self.mqtt_data = MQTTData()
         self.rrm_data = RRMData(rrm_command=f"{mqtt_topic}/command")
         self.pkohelrs_data = PkohelrsData()
-        self._notification_listeners: Set[str] = set()
+        self._notification_listeners: Dict[str, Callable[[], None]] = {}
 
     async def update_data(self, process: bool = True):
         """
@@ -385,7 +385,7 @@ class ValetudoConnector:
           processed=True (e.g. dismissed in the Valetudo web UI), the HA
           notification is dismissed automatically.
         """
-        if not events or not isinstance(events, dict):
+        if events is None or not isinstance(events, dict):
             return
         self.mqtt_data.valetudo_events = events
         for event_id, event_data in events.items():
@@ -398,11 +398,14 @@ class ValetudoConnector:
                 notification_id = f"valetudo_error_{event_id}"
                 if processed:
                     # Event acknowledged (via any interface) — clear the HA notification.
+                    # Unsubscribe BEFORE dismissing so our own dismiss call doesn't
+                    # echo back through the REMOVED callback and re-publish the
+                    # interact command Valetudo already processed.
+                    self._unsubscribe_notification_listener(notification_id)
                     persistent_notification.async_dismiss(
                         self.connector_data.hass,
                         notification_id=notification_id,
                     )
-                    self._notification_listeners.discard(notification_id)
                 else:
                     error_message = event_data.get("message", "Unknown error")
                     self.mqtt_data.mqtt_vac_err = error_message
@@ -418,37 +421,55 @@ class ValetudoConnector:
                         event_id, "ok", notification_id
                     )
 
+    def _unsubscribe_notification_listener(self, notification_id: str) -> None:
+        """Remove and invoke a tracked persistent-notification callback, if any."""
+        unsubscribe = self._notification_listeners.pop(notification_id, None)
+        if unsubscribe is None:
+            return
+        unsubscribe()
+        if unsubscribe in self.connector_data.unsubscribe_handlers:
+            self.connector_data.unsubscribe_handlers.remove(unsubscribe)
+
     def _register_notification_dismiss_listener(
         self, event_id: str, interaction: str, notification_id: str
     ) -> None:
-        """Register a one-time state-change listener for a persistent notification.
+        """Register a dispatcher callback for persistent-notification removal.
 
-        When the HA notification entity is removed (new_state is None), the user
-        dismissed it. We then call _dismiss_valetudo_event to publish the interact
-        command to Valetudo via MQTT, completing the HA → Valetudo direction of
-        the bidirectional sync.
+        Persistent notifications stopped creating state machine entities in
+        Home Assistant 2023.6, so tracking ``persistent_notification.<id>`` via
+        ``async_track_state_change_event`` never fires. We use
+        ``persistent_notification.async_register_callback`` and match on
+        ``UpdateType.REMOVED`` + our ``notification_id`` instead.
+
+        When the user dismisses the HA notification the callback schedules
+        ``_dismiss_valetudo_event`` to publish the interact command, completing
+        the HA → Valetudo direction of the bidirectional sync.
 
         Guards against duplicate registration: if a listener is already tracked
         for this notification_id, the call is a no-op.
         """
         if notification_id in self._notification_listeners:
             return
-        self._notification_listeners.add(notification_id)
-
-        entity_id = f"persistent_notification.{notification_id}"
 
         @callback
-        def _on_state_change(event: Any) -> None:
-            if event.data.get("new_state") is None:
-                # Entity removed → notification was dismissed in HA
-                self._notification_listeners.discard(notification_id)
+        def _on_notification_update(
+            update_type: persistent_notification.UpdateType,
+            notifications: Dict[str, Any],
+        ) -> None:
+            if (
+                update_type == persistent_notification.UpdateType.REMOVED
+                and notification_id in notifications
+            ):
+                # Notification dismissed in HA — propagate back to Valetudo.
+                self._unsubscribe_notification_listener(notification_id)
                 self.connector_data.hass.async_create_task(
                     self._dismiss_valetudo_event(event_id, interaction)
                 )
 
-        unsub = async_track_state_change_event(
-            self.connector_data.hass, [entity_id], _on_state_change
+        unsub = persistent_notification.async_register_callback(
+            self.connector_data.hass, _on_notification_update
         )
+        self._notification_listeners[notification_id] = unsub
         self.connector_data.unsubscribe_handlers.append(unsub)
 
     async def _dismiss_valetudo_event(self, event_id: str, interaction: str) -> None:

--- a/custom_components/mqtt_vacuum_camera/utils/connection/connector.py
+++ b/custom_components/mqtt_vacuum_camera/utils/connection/connector.py
@@ -5,10 +5,11 @@ Last Updated on version: 2025.10.0
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 from homeassistant.components import mqtt, persistent_notification
 from homeassistant.core import EventOrigin, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
 from valetudo_map_parser.config.types import RoomStore
 
 from custom_components.mqtt_vacuum_camera.common import (
@@ -155,6 +156,7 @@ class ValetudoConnector:
         self.mqtt_data = MQTTData()
         self.rrm_data = RRMData(rrm_command=f"{mqtt_topic}/command")
         self.pkohelrs_data = PkohelrsData()
+        self._notification_listeners: Set[str] = set()
 
     async def update_data(self, process: bool = True):
         """
@@ -364,23 +366,113 @@ class ValetudoConnector:
         self.config.shared.dock_state = dock_text
 
     async def _hypfer_handle_valetudo_events(self, events) -> None:
-        """Handle Valetudo events (errors, warnings, etc.)."""
-        if events and isinstance(events, dict):
-            self.mqtt_data.valetudo_events = events
-            # Extract error messages from unprocessed events
-            for event_id, event_data in events.items():
-                if isinstance(event_data, dict) and not event_data.get(
-                    "processed", True
-                ):
-                    if event_data.get("__class") == "ErrorStateValetudoEvent":
-                        error_message = event_data.get("message", "Unknown error")
-                        self.mqtt_data.mqtt_vac_err = error_message
-                        persistent_notification.async_create(
-                            self.connector_data.hass,
-                            message=f"**{self.connector_data.file_name}**\n\n{error_message}",
-                            title="Valetudo Error",
-                            notification_id=f"valetudo_error_{event_id}",
-                        )
+        """Handle Valetudo events (errors, warnings, etc.).
+
+        Valetudo retains the events topic in MQTT. Each event has a 'processed'
+        flag that Valetudo sets to True once the event has been acknowledged via
+        any interface (its own web UI, the HTTP API, or the MQTT interact topic).
+        'processed' does NOT mean a specific interface was used — it just means
+        someone acknowledged it somewhere.
+
+        Bidirectional sync:
+        - Valetudo → HA: when an unprocessed event arrives, a persistent
+          notification is created in HA and a state-change listener is registered
+          so that dismissing the notification propagates back to Valetudo.
+        - HA → Valetudo: when the user dismisses the HA notification,
+          _dismiss_valetudo_event publishes to the MQTT interact topic, causing
+          Valetudo to mark the event as processed and republish the events topic.
+        - Valetudo → HA (reverse): when Valetudo republishes the event with
+          processed=True (e.g. dismissed in the Valetudo web UI), the HA
+          notification is dismissed automatically.
+        """
+        if not events or not isinstance(events, dict):
+            return
+        self.mqtt_data.valetudo_events = events
+        for event_id, event_data in events.items():
+            if not isinstance(event_data, dict):
+                continue
+            event_class = event_data.get("__class", "")
+            processed = event_data.get("processed", True)
+
+            if event_class == "ErrorStateValetudoEvent":
+                notification_id = f"valetudo_error_{event_id}"
+                if processed:
+                    # Event acknowledged (via any interface) — clear the HA notification.
+                    persistent_notification.async_dismiss(
+                        self.connector_data.hass,
+                        notification_id=notification_id,
+                    )
+                    self._notification_listeners.discard(notification_id)
+                else:
+                    error_message = event_data.get("message", "Unknown error")
+                    self.mqtt_data.mqtt_vac_err = error_message
+                    persistent_notification.async_create(
+                        self.connector_data.hass,
+                        message=f"**{self.connector_data.file_name}**\n\n{error_message}",
+                        title="Valetudo Error",
+                        notification_id=notification_id,
+                    )
+                    # Watch for the HA notification being dismissed so we can
+                    # propagate the dismissal back to Valetudo.
+                    self._register_notification_dismiss_listener(
+                        event_id, "ok", notification_id
+                    )
+
+    def _register_notification_dismiss_listener(
+        self, event_id: str, interaction: str, notification_id: str
+    ) -> None:
+        """Register a one-time state-change listener for a persistent notification.
+
+        When the HA notification entity is removed (new_state is None), the user
+        dismissed it. We then call _dismiss_valetudo_event to publish the interact
+        command to Valetudo via MQTT, completing the HA → Valetudo direction of
+        the bidirectional sync.
+
+        Guards against duplicate registration: if a listener is already tracked
+        for this notification_id, the call is a no-op.
+        """
+        if notification_id in self._notification_listeners:
+            return
+        self._notification_listeners.add(notification_id)
+
+        entity_id = f"persistent_notification.{notification_id}"
+
+        @callback
+        def _on_state_change(event: Any) -> None:
+            if event.data.get("new_state") is None:
+                # Entity removed → notification was dismissed in HA
+                self._notification_listeners.discard(notification_id)
+                self.connector_data.hass.async_create_task(
+                    self._dismiss_valetudo_event(event_id, interaction)
+                )
+
+        unsub = async_track_state_change_event(
+            self.connector_data.hass, [entity_id], _on_state_change
+        )
+        self.connector_data.unsubscribe_handlers.append(unsub)
+
+    async def _dismiss_valetudo_event(self, event_id: str, interaction: str) -> None:
+        """Publish an interact command to Valetudo via MQTT to mark an event as processed.
+
+        Valetudo's MQTT interact topic expects:
+            {"id": "<event_id>", "interaction": "<interaction>"}
+
+        The interaction value is event-class-specific:
+            - ErrorStateValetudoEvent       → "ok"
+            - ConsumableDepletedValetudoEvent → "reset"
+
+        Source: ValetudoEventsNodeMqttHandle.js in the Valetudo backend.
+        """
+        topic = f"{self.config.mqtt_topic}/ValetudoEvents/valetudo_events/interact/set"
+        await self.publish_to_broker(
+            topic, {"id": event_id, "interaction": interaction}
+        )
+        LOGGER.debug(
+            "%s: Sent dismiss for Valetudo event %s (interaction=%s)",
+            self.connector_data.file_name,
+            event_id,
+            interaction,
+        )
 
     async def _rand256_handle_image_payload(self, msg) -> None:
         """Handle Rand256 image payload."""

--- a/tests/test_connector_valetudo_events.py
+++ b/tests/test_connector_valetudo_events.py
@@ -1,5 +1,6 @@
 """Tests for Valetudo event dismiss propagation in ValetudoConnector."""
 
+from typing import Any, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -69,10 +70,8 @@ async def test_creates_notification_for_unprocessed_error():
 
     with patch(
         "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
-    ) as mock_pn, patch(
-        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event"
-    ) as mock_track:
-        mock_track.return_value = MagicMock()
+    ) as mock_pn:
+        mock_pn.async_register_callback.return_value = MagicMock()
         await connector._hypfer_handle_valetudo_events(events)
 
     mock_pn.async_create.assert_called_once()
@@ -114,8 +113,8 @@ async def test_ignores_non_error_classes():
 
 
 @pytest.mark.asyncio
-async def test_does_nothing_on_empty_events():
-    """Empty or None events payload is handled gracefully."""
+async def test_none_or_empty_events_does_not_notify():
+    """None or empty-dict payloads never create/dismiss notifications."""
     connector = _make_connector()
     with patch(
         "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
@@ -137,28 +136,272 @@ async def test_listener_registered_only_once_per_notification():
     connector = _make_connector()
 
     with patch(
-        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event"
-    ) as mock_track:
-        mock_track.return_value = MagicMock()
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.return_value = MagicMock()
         connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
         connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
 
-    assert mock_track.call_count == 1
+    assert mock_pn.async_register_callback.call_count == 1
 
 
 @pytest.mark.asyncio
 async def test_listener_unsubscribe_added_to_handlers():
-    """The unsubscribe callable from async_track_state_change_event is stored."""
+    """The unsubscribe callable from async_register_callback is stored for cleanup."""
     connector = _make_connector()
     mock_unsub = MagicMock()
 
     with patch(
-        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event",
-        return_value=mock_unsub,
-    ):
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.return_value = mock_unsub
         connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
 
     assert mock_unsub in connector.connector_data.unsubscribe_handlers
+    assert connector._notification_listeners["valetudo_error_evt-1"] is mock_unsub
+
+
+@pytest.mark.asyncio
+async def test_removed_callback_dismisses_valetudo_event():
+    """When HA dispatches UpdateType.REMOVED for our notification, propagate back to Valetudo."""
+    connector = _make_connector()
+    # MagicMock (not AsyncMock) — the code passes its return value to the
+    # mocked hass.async_create_task which never awaits it; AsyncMock would
+    # leak an un-awaited coroutine and emit RuntimeWarning.
+    connector._dismiss_valetudo_event = MagicMock()
+
+    captured = []
+
+    def _capture(_hass, cb):
+        captured.append(cb)
+        return MagicMock()
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.side_effect = _capture
+        removed_sentinel = object()
+        mock_pn.UpdateType.REMOVED = removed_sentinel
+
+        connector._register_notification_dismiss_listener(
+            "evt-1", "ok", "valetudo_error_evt-1"
+        )
+        assert len(captured) == 1
+
+        # Simulate HA dispatching the removal of our notification
+        captured[0](removed_sentinel, {"valetudo_error_evt-1": object()})
+
+    connector._dismiss_valetudo_event.assert_called_once_with("evt-1", "ok")
+    # Listener must be cleaned up from both tracking structures to avoid
+    # leaking stale entries in connector_data.unsubscribe_handlers.
+    assert "valetudo_error_evt-1" not in connector._notification_listeners
+    assert connector.connector_data.unsubscribe_handlers == []
+
+
+@pytest.mark.asyncio
+async def test_removed_callback_ignores_other_notifications():
+    """REMOVED events for unrelated notification_ids must not trigger dismissal."""
+    connector = _make_connector()
+    # MagicMock (not AsyncMock) — the code passes its return value to the
+    # mocked hass.async_create_task which never awaits it; AsyncMock would
+    # leak an un-awaited coroutine and emit RuntimeWarning.
+    connector._dismiss_valetudo_event = MagicMock()
+
+    captured = []
+
+    def _capture(_hass, cb):
+        captured.append(cb)
+        return MagicMock()
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.side_effect = _capture
+        removed_sentinel = object()
+        added_sentinel = object()
+        mock_pn.UpdateType.REMOVED = removed_sentinel
+        mock_pn.UpdateType.ADDED = added_sentinel
+
+        connector._register_notification_dismiss_listener(
+            "evt-1", "ok", "valetudo_error_evt-1"
+        )
+        # REMOVED for a different notification id
+        captured[0](removed_sentinel, {"something_else": object()})
+        # ADDED for our notification id
+        captured[0](added_sentinel, {"valetudo_error_evt-1": object()})
+
+    connector._dismiss_valetudo_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_processed_event_unsubscribes_before_dismissing():
+    """When Valetudo marks an event processed, unsubscribe BEFORE async_dismiss to prevent echo-back."""
+    connector = _make_connector()
+    mock_unsub = MagicMock()
+
+    # First, register a listener as if an unprocessed event arrived earlier.
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.return_value = mock_unsub
+        connector._register_notification_dismiss_listener(
+            "evt-1", "ok", "valetudo_error_evt-1"
+        )
+    assert "valetudo_error_evt-1" in connector._notification_listeners
+
+    # Now Valetudo sends processed=True — we must unsubscribe before dismissing.
+    events = {"evt-1": _make_error_event("evt-1", processed=True)}
+    call_order = []
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_unsub.side_effect = lambda: call_order.append("unsubscribe")
+        mock_pn.async_dismiss.side_effect = lambda *a, **kw: call_order.append("dismiss")
+        await connector._hypfer_handle_valetudo_events(events)
+
+    assert call_order == ["unsubscribe", "dismiss"]
+    assert "valetudo_error_evt-1" not in connector._notification_listeners
+
+
+@pytest.mark.asyncio
+async def test_full_flow_user_dismisses_in_ha_publishes_to_valetudo():
+    """End-to-end: unprocessed event → HA dismissal → MQTT interact publish.
+
+    Exercises the full code path without mocking _dismiss_valetudo_event:
+      1. Valetudo publishes an unprocessed ErrorStateValetudoEvent.
+      2. _hypfer_handle_valetudo_events creates the notification and registers
+         a real dismissal listener.
+      3. User dismisses the notification in HA (simulated by invoking the
+         captured dispatcher callback with UpdateType.REMOVED).
+      4. The scheduled _dismiss_valetudo_event runs and must publish an
+         interact command with the exact payload Valetudo expects.
+    """
+    connector = _make_connector()
+    connector.publish_to_broker = AsyncMock()
+
+    # Collect coroutines scheduled via hass.async_create_task so we can await them.
+    scheduled_coros: List[Any] = []
+    connector.connector_data.hass.async_create_task = lambda coro: scheduled_coros.append(coro)
+
+    captured_callbacks: List[Any] = []
+
+    def _capture(_hass, cb):
+        captured_callbacks.append(cb)
+        return MagicMock()
+
+    # Step 1–2: Valetudo sends an unprocessed error.
+    events = {"evt-42": _make_error_event("evt-42", processed=False, message="Brush stuck")}
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.side_effect = _capture
+        removed_sentinel = object()
+        mock_pn.UpdateType.REMOVED = removed_sentinel
+
+        await connector._hypfer_handle_valetudo_events(events)
+
+        # Notification created for the user.
+        mock_pn.async_create.assert_called_once()
+        assert mock_pn.async_create.call_args.kwargs["notification_id"] == "valetudo_error_evt-42"
+
+        # A listener was registered with HA's dispatcher.
+        assert len(captured_callbacks) == 1
+        ha_callback = captured_callbacks[0]
+
+        # Step 3: user dismisses the notification in HA — HA dispatches REMOVED.
+        ha_callback(removed_sentinel, {"valetudo_error_evt-42": object()})
+
+    # The callback scheduled _dismiss_valetudo_event; await the real coroutine.
+    assert len(scheduled_coros) == 1
+    await scheduled_coros[0]
+
+    # Step 4: MQTT interact command actually published with correct payload.
+    connector.publish_to_broker.assert_awaited_once_with(
+        "valetudo/TestRobot/ValetudoEvents/valetudo_events/interact/set",
+        {"id": "evt-42", "interaction": "ok"},
+    )
+
+    # And the listener tracking is fully cleaned up.
+    assert "valetudo_error_evt-42" not in connector._notification_listeners
+    assert connector.connector_data.unsubscribe_handlers == []
+
+
+@pytest.mark.asyncio
+async def test_full_flow_dismissal_in_valetudo_does_not_echo_to_mqtt():
+    """End-to-end: when Valetudo-side dismissal arrives (processed=True),
+    the HA notification is dismissed but NO MQTT interact is published.
+
+    This exercises the echo-back prevention: unsubscribe fires before
+    async_dismiss, so HA's own REMOVED dispatch doesn't retrigger the
+    callback that would republish to Valetudo.
+
+    Simulates HA's dispatcher faithfully: callbacks live in a list, the
+    returned unsubscribe removes them from that list, and async_dismiss
+    dispatches only to callbacks still registered at the time.
+    """
+    connector = _make_connector()
+    connector.publish_to_broker = AsyncMock()
+
+    scheduled_coros: List[Any] = []
+    connector.connector_data.hass.async_create_task = lambda coro: scheduled_coros.append(coro)
+
+    # Faithful HA dispatcher simulation.
+    dispatcher: List[Any] = []
+    removed_sentinel = object()
+
+    def _register(_hass, cb):
+        dispatcher.append(cb)
+
+        def _unsubscribe():
+            if cb in dispatcher:
+                dispatcher.remove(cb)
+
+        return _unsubscribe
+
+    def _dispatch_removed(notification_id: str) -> None:
+        """Invoke all currently-registered callbacks, like HA would."""
+        for cb in list(dispatcher):
+            cb(removed_sentinel, {notification_id: object()})
+
+    # Arm: unprocessed event arrives first so a listener is registered.
+    unprocessed = {"evt-7": _make_error_event("evt-7", processed=False, message="Filter clog")}
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        mock_pn.async_register_callback.side_effect = _register
+        mock_pn.UpdateType.REMOVED = removed_sentinel
+        # In real HA, async_dismiss would trigger the dispatcher. Wire that up.
+        mock_pn.async_dismiss.side_effect = lambda _hass, notification_id: _dispatch_removed(
+            notification_id
+        )
+
+        await connector._hypfer_handle_valetudo_events(unprocessed)
+        assert len(dispatcher) == 1, "listener should be in the dispatcher"
+
+        # Simulate Valetudo-side dismissal: processed=True arrives.
+        processed = {"evt-7": _make_error_event("evt-7", processed=True)}
+        await connector._hypfer_handle_valetudo_events(processed)
+
+    # async_dismiss fired the dispatcher, but our callback was already gone
+    # because _unsubscribe_notification_listener ran first — no echo.
+    assert dispatcher == [], "listener should have been removed before async_dismiss"
+    assert scheduled_coros == [], "no _dismiss_valetudo_event should have been scheduled"
+    connector.publish_to_broker.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_events_dict_clears_stale_events():
+    """An empty-dict payload must overwrite previously stored events (not be ignored)."""
+    connector = _make_connector()
+    connector.mqtt_data.valetudo_events = {"stale": {"__class": "ErrorStateValetudoEvent"}}
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ):
+        await connector._hypfer_handle_valetudo_events({})
+
+    assert connector.mqtt_data.valetudo_events == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_connector_valetudo_events.py
+++ b/tests/test_connector_valetudo_events.py
@@ -1,0 +1,193 @@
+"""Tests for Valetudo event dismiss propagation in ValetudoConnector."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.mqtt_vacuum_camera.utils.connection.connector import (
+    ValetudoConnector,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_connector():
+    """Build a ValetudoConnector with minimal mocks."""
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    shared = MagicMock()
+    shared.file_name = "test_vacuum"
+    shared.camera_mode = MagicMock()
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.RoomStore"
+    ):
+        connector = ValetudoConnector(
+            mqtt_topic="valetudo/TestRobot",
+            hass=hass,
+            camera_shared=shared,
+        )
+
+    return connector
+
+
+def _make_error_event(event_id, processed=False, message="Test error"):
+    return {
+        "__class": "ErrorStateValetudoEvent",
+        "id": event_id,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "processed": processed,
+        "message": message,
+        "metaData": {},
+    }
+
+
+def _make_consumable_event(event_id, processed=False):
+    return {
+        "__class": "ConsumableDepletedValetudoEvent",
+        "id": event_id,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "processed": processed,
+        "type": "cleaning",
+        "subType": "wheel",
+        "metaData": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _hypfer_handle_valetudo_events
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_creates_notification_for_unprocessed_error():
+    """An unprocessed ErrorStateValetudoEvent creates a persistent notification."""
+    connector = _make_connector()
+    events = {"evt-1": _make_error_event("evt-1", processed=False, message="Mop pad failure")}
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn, patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event"
+    ) as mock_track:
+        mock_track.return_value = MagicMock()
+        await connector._hypfer_handle_valetudo_events(events)
+
+    mock_pn.async_create.assert_called_once()
+    call_kwargs = mock_pn.async_create.call_args
+    assert call_kwargs[1]["notification_id"] == "valetudo_error_evt-1"
+    assert "Mop pad failure" in call_kwargs[1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_dismisses_ha_notification_when_event_becomes_processed():
+    """When Valetudo marks an event processed, the HA notification is dismissed."""
+    connector = _make_connector()
+    events = {"evt-1": _make_error_event("evt-1", processed=True)}
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        await connector._hypfer_handle_valetudo_events(events)
+
+    mock_pn.async_dismiss.assert_called_once_with(
+        connector.connector_data.hass,
+        notification_id="valetudo_error_evt-1",
+    )
+    mock_pn.async_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_error_classes():
+    """Non-error event classes that aren't handled don't create notifications."""
+    connector = _make_connector()
+    events = {"evt-x": _make_consumable_event("evt-x", processed=False)}
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        await connector._hypfer_handle_valetudo_events(events)
+
+    mock_pn.async_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_does_nothing_on_empty_events():
+    """Empty or None events payload is handled gracefully."""
+    connector = _make_connector()
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.persistent_notification"
+    ) as mock_pn:
+        await connector._hypfer_handle_valetudo_events(None)
+        await connector._hypfer_handle_valetudo_events({})
+
+    mock_pn.async_create.assert_not_called()
+    mock_pn.async_dismiss.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _register_notification_dismiss_listener
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_listener_registered_only_once_per_notification():
+    """Calling register twice for the same notification_id is a no-op the second time."""
+    connector = _make_connector()
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event"
+    ) as mock_track:
+        mock_track.return_value = MagicMock()
+        connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
+        connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
+
+    assert mock_track.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_listener_unsubscribe_added_to_handlers():
+    """The unsubscribe callable from async_track_state_change_event is stored."""
+    connector = _make_connector()
+    mock_unsub = MagicMock()
+
+    with patch(
+        "custom_components.mqtt_vacuum_camera.utils.connection.connector.async_track_state_change_event",
+        return_value=mock_unsub,
+    ):
+        connector._register_notification_dismiss_listener("evt-1", "ok", "valetudo_error_evt-1")
+
+    assert mock_unsub in connector.connector_data.unsubscribe_handlers
+
+
+# ---------------------------------------------------------------------------
+# _dismiss_valetudo_event
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dismiss_publishes_to_mqtt_interact_topic():
+    """_dismiss_valetudo_event publishes the correct payload to the MQTT interact topic."""
+    connector = _make_connector()
+    connector.publish_to_broker = AsyncMock()
+
+    await connector._dismiss_valetudo_event("evt-1", "ok")
+
+    connector.publish_to_broker.assert_called_once_with(
+        "valetudo/TestRobot/ValetudoEvents/valetudo_events/interact/set",
+        {"id": "evt-1", "interaction": "ok"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_dismiss_uses_correct_interaction_per_event_type():
+    """Different interaction values are forwarded as-is to the MQTT topic."""
+    connector = _make_connector()
+    connector.publish_to_broker = AsyncMock()
+
+    await connector._dismiss_valetudo_event("consumable-1", "reset")
+
+    connector.publish_to_broker.assert_called_once_with(
+        "valetudo/TestRobot/ValetudoEvents/valetudo_events/interact/set",
+        {"id": "consumable-1", "interaction": "reset"},
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Register camera_select_floor and camera_update_floor_data services
  in async_setup_entry; unregister them in async_unload_entry (__init__.py)
- Add camera_select_floor: sets CONF_CURRENT_FLOOR on the config entry
  and fires event_mqtt_vacuum_camera_floor_selected
- Add camera_update_floor_data: reads current trims from coordinator,
  builds a FloorData object and persists it to CONF_FLOORS_DATA on the
  config entry, then fires event_mqtt_vacuum_camera_floor_data_updated
- Add private helpers _resolve_camera_entity_id and
  _get_config_entry_from_camera (camera_services.py)
- Bump version 2026.3.1 → 2026.4.0 (manifest.json)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to our integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format`)
- [x] The code has been been check with pylint.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated.

If the code communicates uses new third-party tools or libraries:

- [x] New or updated dependencies have been added to `manifest.json`.  
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Ensure your pull request is based on the `dev` branch, not `main`.

<!--
  This project quite active and we have a small turnover of pull requests.

  For incoming pull requests our reviewers can review and merge as soon it will be possible 
  so as pere there is not a long backlog of pull requests waiting for review.

  We are looking forward to review and working with you.

  Thanks for helping out!
-->



<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added floor selection functionality to manage active floors for camera vacuum operations.
  * Added the ability to persist auto-calculated map trim data to floor-specific configurations.
  * Enhanced Valetudo error event handling with bidirectional dismissal synchronization—error dismissals in Home Assistant now automatically propagate back to the vacuum device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->