### PR TITLE
Remove unused import in coordinator.py

### DIFF
--- a/custom_components/mqtt_vacuum_camera/coordinator.py
+++ b/custom_components/mqtt_vacuum_camera/coordinator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Optional
 
 import async_timeout
-from homeassistant.helpers.device_registry import DeviceInfo
+
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from valetudo_map_parser.config.shared import CameraSharedManager
 


### PR DESCRIPTION
## Background
A lint analysis identified that the import of `homeassistant.helpers.device_registry.DeviceInfo` in `custom_components/mqtt_vacuum_camera/coordinator.py` is unused. This can lead to unnecessary dependencies and reduced code clarity.

## Changes
- Removed the unused `DeviceInfo` import to improve code cleanliness and adhere to best practices for minimal dependencies.

## Verification
- The code functionality remains unchanged as the imported module was not referenced anywhere in the file.
- Verified by ensuring no lint warnings for unused imports and confirming the integration still works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and optimization

---

*No user-facing changes or new features in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->